### PR TITLE
EPIC and CASA specification

### DIFF
--- a/doc/protocols/casa.rst
+++ b/doc/protocols/casa.rst
@@ -39,8 +39,8 @@ Description
 -----------
 In CASA, every AS chooses exactly **one algorithm** per algorithm 
 category. Those categories are globally defined and can either be 
-general (PRF, MAC, ...) or protocol-specific (DRKEY-PRF, 
-EPIC-MAC-HVF, EPIC-MAC-DVF, ...).
+general (PRF, MAC, ...) or protocol-specific (PRF-DRKEY, 
+MAC-EPIC-HVF, MAC-EPIC-DVF, ...).
 
 ::
 
@@ -49,11 +49,11 @@ EPIC-MAC-HVF, EPIC-MAC-DVF, ...).
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     | PRF:          | CBC-MAC-AES |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    | DRKEY-PRF:    | CBC-MAC-AES |
+    | MAC-EPIC-HVF: | Poly1305    |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    | EPIC-MAC-HVF: | Poly1305    |
+    | MAC-EPIC-DVF: | Poly1305    |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    | EPIC-MAC-DVF: | Poly1305    |
+    | PRF-DRKEY:    | CBC-MAC-AES |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     | ...           | ...         |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -68,6 +68,14 @@ performance.
 Those algorithms are then primarily announced in the beacons, but 
 can also be exchanged in protocol-specific channels, for example 
 when ASes fetch each others first-level DRKeys.
+
+Note the asymmetry in the CASA design: 
+There is in general one side with higher and one with lower 
+efficiency requirements. The side that requires higher efficiency 
+chooses the algorithm to be used, as it is the one that is primarily 
+affected by the algorithm's performance. This mirrors the design of 
+DRKey, where one side has to fetch the key (slow), and the other side 
+can recompute the key on the fly (fast). 
 
 Beaconing Extensions
 --------------------
@@ -90,4 +98,16 @@ meaning that no additional fields are necessary.
 The border routers of the ASes only need to implement the small 
 number of algorithms promoted by their AS, which minimizes their 
 overhead and prevents performance degradation.
+
+Algorithm Categories
+--------------------
+The following categories are supported:
+
+MAC
+^^^
+This category contains the following MAC algorithms: 
+
+PRF
+^^^
+This category contains the following PRF algorithms: 
 

--- a/doc/protocols/casa.rst
+++ b/doc/protocols/casa.rst
@@ -28,7 +28,8 @@ for each AS, which identifies the selected algorithm. For DRKey and
 EPIC, border routers would need to potentially support many 
 different algorithms, which hinders scalability and performance.
 Also, border routers are likely less agile in adopting new 
-cryptographic algorithms.
+cryptographic algorithms as they often contain dedicated hardware for packet 
+processing.
 
 
 CASA can provide most of the advantages of both those two options, 
@@ -117,4 +118,3 @@ This category contains the following MAC algorithms:
 PRF
 ^^^
 This category contains the following PRF algorithms: 
-

--- a/doc/protocols/casa.rst
+++ b/doc/protocols/casa.rst
@@ -27,6 +27,9 @@ that the data plane packets need to introduce an additional field
 for each AS, which identifies the selected algorithm. For DRKey and 
 EPIC, border routers would need to potentially support many 
 different algorithms, which hinders scalability and performance.
+Also, border routers are likely less agile in adopting new 
+cryptographic algorithms.
+
 
 CASA can provide most of the advantages of both those two options, 
 while avoiding their drawbacks: it is a tradeoff between simplicity 
@@ -64,6 +67,8 @@ entities.
 On the other hand, the protocol-specific categories serve the needs 
 of protocols that have additional requirements like high 
 performance. 
+In case an algorithm for a protocol-specific category is announced, 
+it has priority over the one specified in the general category. 
 
 Those algorithms are then primarily announced in the beacons, but 
 can also be exchanged in protocol-specific channels, for example 
@@ -91,7 +96,9 @@ due to CASA amounts to 80 bytes.
 Advantages
 ----------
 With CASA, every AS is free to choose which cryptographic algorithms 
-it wants to support, there is no global agreement necessary. 
+it wants to support, there is no global agreement necessary, 
+except for the different categories and their options regarding the 
+algorithms. 
 Furthermore, CASA introduces only a small overhead in the beacons 
 and does not affect the layout of the data plane packets in any way, 
 meaning that no additional fields are necessary.

--- a/doc/protocols/casa.rst
+++ b/doc/protocols/casa.rst
@@ -1,0 +1,93 @@
+******************
+CASA Specification
+******************
+
+This document contains the specification of the CASA (Cryptographic 
+Agility for SCION ASes) protocol.
+
+Background
+==========
+In SCION, several protocols like DRKey and EPIC require different 
+entities (ASes, hosts) to agree on the same cryptographic 
+algorithms like PRFs and MACs.
+
+The simplest solution would be to globally define the algorithm 
+(e.g. AES-based CMAC) that is used by such a protocol. If an 
+algorithm becomes obsolete, the protocol can be redefined using a 
+new Path Type, and another algorithm may be introduced. This 
+solution assumes that all the ASes in the whole Internet can agree 
+on the same cryptographic algorithms.
+
+However, ASes may want to be more flexible in the choice of the 
+algorithms they support. A more sophistic approach would be that 
+each AS promotes the subset of algorithms (from some globally 
+defined set of algorithms) that it supports, similarly to the 
+exchange of cipher suites in TLS handshakes. This means however, 
+that the data plane packets need to introduce an additional field, 
+which identifies the selected algorithm. For DRKey and EPIC, border 
+routers would need to potentially support many different algorithms, 
+which hinders scalability and performance.
+
+CASA can provide most of the advantages of both those two options, 
+while avoiding their drawbacks: it is a tradeoff between simplicity 
+and agility.
+
+Specification
+=============
+
+Description
+-----------
+In CASA, every AS chooses exactly **one algorithm** per algorithm 
+category. Those categories are globally defined and can either be 
+general (PRF, MAC, ...) or protocol-specific (DRKEY-PRF, 
+EPIC-MAC-HVF, EPIC-MAC-DVF, ...).
+
+::
+
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | MAC:          | CMAC-AES    |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | PRF:          | CBC-MAC-AES |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | DRKEY-PRF:    | CBC-MAC-AES |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | EPIC-MAC-HVF: | Poly1305    |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | EPIC-MAC-DVF: | Poly1305    |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | ...           | ...         |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+The idea behind the general categories is to cover a large set of 
+protocols that only need algorithm agreement between different 
+entities.
+On the other hand, the protocol-specific categories serve the needs 
+of protocols that have additional requirements like high 
+performance. 
+
+Those algorithms are then primarily announced in the beacons, but 
+can also be exchanged in protocol-specific channels, for example 
+when ASes fetch each others first-level DRKeys.
+
+Beaconing Extensions
+--------------------
+For each category, the beacon needs to be extended by a field that 
+indicates the concrete algorithm implementation that an AS supports. 
+With a field size of one byte, there are 256 possible algorithms per 
+category.
+
+For a scenario with ten different categories and a path consisting 
+of eight ASes, the communication overhead introduced in the beacons 
+due to CASA amounts to 80 bytes.
+
+Advantages
+----------
+With CASA, every AS is free to choose which cryptographic algorithms 
+it wants to support, there is no global agreement necessary. 
+Furthermore, CASA introduces only a small overhead in the beacons 
+and does not affect the layout of the data plane packets in any way, 
+meaning that no additional fields are necessary.
+The border routers of the ASes only need to implement the small 
+number of algorithms promoted by their AS, which minimizes their 
+overhead and prevents performance degradation.
+

--- a/doc/protocols/casa.rst
+++ b/doc/protocols/casa.rst
@@ -71,9 +71,9 @@ performance.
 In case an algorithm for a protocol-specific category is announced, 
 it has priority over the one specified in the general category. 
 
-Those algorithms are then primarily announced in the beacons, but 
-can also be exchanged in protocol-specific channels, for example 
-when ASes fetch each others first-level DRKeys.
+Those algorithms are then announced in the beacons, so that this 
+information is directly available and does not need to be fetched 
+(from every on-path AS) by each protocol separately.
 
 Note the asymmetry in the CASA design: 
 There is in general one side with higher and one with lower 

--- a/doc/protocols/casa.rst
+++ b/doc/protocols/casa.rst
@@ -23,10 +23,10 @@ algorithms they support. A more sophistic approach would be that
 each AS promotes the subset of algorithms (from some globally 
 defined set of algorithms) that it supports, similarly to the 
 exchange of cipher suites in TLS handshakes. This means however, 
-that the data plane packets need to introduce an additional field, 
-which identifies the selected algorithm. For DRKey and EPIC, border 
-routers would need to potentially support many different algorithms, 
-which hinders scalability and performance.
+that the data plane packets need to introduce an additional field 
+for each AS, which identifies the selected algorithm. For DRKey and 
+EPIC, border routers would need to potentially support many 
+different algorithms, which hinders scalability and performance.
 
 CASA can provide most of the advantages of both those two options, 
 while avoiding their drawbacks: it is a tradeoff between simplicity 

--- a/doc/protocols/scion-header.rst
+++ b/doc/protocols/scion-header.rst
@@ -420,7 +420,7 @@ security of hidden paths.
 
 The EPIC-HP header has the following structure:
    - A *PacketTimestamp* field (8 bytes)
-   - The standard SCION header
+   - The path header for the standard SCION Path Type
    - A 4-byte *LHVF* (Last Hop Verification Field) 
 
 The EPIC-HP contains the full SCION header, and also the calculation of the MAC is identical. This allows 

--- a/doc/protocols/scion-header.rst
+++ b/doc/protocols/scion-header.rst
@@ -408,3 +408,311 @@ Because of its special structure, no PathMeta header is needed. There is only a
 single info field and the appropriate hop field can be processed by a border
 router based on the source and destination address, i.e., ``if srcIA == self.IA:
 CurrHF := 0`` and ``if dstIA == self.IA: CurrHF := 1``.
+
+
+
+
+
+
+
+
+.. -------------------------------------------------------------------
+
+Path Type: EPIC
+===============
+The EPIC Path Type is equal to the SCION Path Type, except for the following additions:
+   - An additional *EV* (EPIC Version) field in the Path Meta Header.
+   - An additional *PacketTimestamp* field (8 bytes), which is placed after the very last HopField.
+   - Depending on the value of EV, the Packet Timestamp is either followed by the 
+     4-byte *LHVF* (Last Hop Verification Field) or by the 16-byte *DVF* (Destination Validation Field).
+
+::
+
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                          PathMetaHdr                          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           InfoField                           |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                              ...                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           InfoField                           |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           HopField                            |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                              ...                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           HopField                            |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                        PacketTimestamp                        |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                          DVF / LHVF                           |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+Path Meta Header
+----------------
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | C |  CurrHF   |  RSV  |EV |  Seg0Len  |  Seg1Len  |  Seg2Len  |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+EPIC Version (EV):
+   - EV = 0: Standard SCION with EPIC L1 only on the last hop of the last segment.
+   - EV = 1: EPIC L2
+   - EV = 2: *unused (may be used for EPIC L3 in the future)*
+   - EV = 3: *unused*
+
+Info Field
+----------
+The EPIC Info Field is the same as the SCION Info Field.
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |r r r r r r P C|      RSV      |             SegID             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           Timestamp                           |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+Hop Field
+---------
+The EPIC Hop Field is the same as the SCION Hop Field.
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |r r r r r r I E|    ExpTime    |           ConsIngress         |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |        ConsEgress             |                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               +
+    |                              MAC                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+For EPIC Version 1, we reduce the size of the MAC field and 
+assign a 4-byte Hop Validation Field (HVF) to the freed space.
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |r r r r r r I E|    ExpTime    |           ConsIngress         |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |        ConsEgress             |              MAC              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                              HVF                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+Packet Timestamp
+----------------
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                             TsRel                             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |    CoreID     |                  CoreCounter                  |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+TsRel
+  A 4-byte timestamp relative to the path Timestamp (we call it 
+  TsPath now) in the Info Field. TsRel is calculated by the 
+  source host as follows:
+
+.. math::    
+    \begin{align}
+    \text{Ts} &= \text{unix timestamp [ms]} \\
+    \text{TsRel} &= \text{Ts} - (1000 \times \text{TsPath [s]}) \\
+    \textit{Get back the time when} &\textit{the packet 
+        was timestamped:} \\
+    \text{Ts} &= (\text{TsPath} \times 1000) + \text{TsRel [ms]} \\
+    \end{align}
+
+CoreID
+  Unique identifier representing one of the cores of the source host.
+  Creating a timestamp can result in collisions when sending packets 
+  at high speeds or when using multiple cores. The combination of 
+  CoreID and CoreCounter can sort out this problem.
+
+CoreCounter
+  Current value of the core counter belonging to the core specified 
+  by CoreID. Every time a core sends an EPIC packet, it increases 
+  its core counter (modular addition by 1).
+
+
+Last Hop Validation Field (LHVF)
+----------------------------------
+::
+
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                             LHVF                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+This 4-byte field is only present if the EPIC Version is 0. It 
+contains the EPIC L1 Hop Validation Field of the last hop of the 
+last segment. 
+
+Destination Validation Field (DVF)
+----------------------------------
+::
+
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    +                                                               +
+    |                                                               |
+    +                              DVF                              +
+    |                                                               |
+    +                                                               +
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+The 16-byte Destination Validation Field is only present if the EPIC 
+Version is 1. The DVF contains the MAC calculated by the source host 
+to authenticate itself to the destination host.
+
+EPIC Header Length Calculation
+------------------------------
+The length of the EPIC Path header is the same as the SCION Path
+header plus 8 bytes (Packet Timestamp), and plus 4 bytes in case of 
+EPIC version 0 or 16 bytes in case of EPIC version 1.
+
+
+Procedures in EPIC Version 0
+----------------------------
+
+**Control plane:**
+The beaconing process is the same as for SCION, but the last hop not 
+only adds the 6 bytes of the truncated MAC, but further appends the 
+remaining 10 bytes, which together define the 16-byte authenticator 
+:math:`{\sigma_{\text{LH}}}` for the last hop (LH). 
+
+**Data plane:**
+The source fetches the path, including all the 6-byte short hop 
+authenticators and the remaining 10 bytes of the last authenticator, 
+from the path server. It copies the short authenticators to the 
+corresponding MAC-subfield of the Hop Fields as in standard SCION 
+and adds the current Packet Timestamp. 
+In addition, it calculates the Last Hop Validation Field as follows:
+
+.. math::    
+    \begin{align}
+    \text{Origin} &= \text{(SrcISD, SrcAS, SrcHostAddr)} \\
+    \text{LHVF} &= \text{MAC}_{\sigma_{\text{LH}}}
+        (\text{PacketTimestamp}, 
+        \text{Origin}, \text{PayloadLen})~\text{[0:4]}
+    \end{align}
+
+The border routers of the on-path ASes validate and forward the 
+data plane packets as in standard SCION (recalculate 
+:math:`\sigma_{i}` and compare to the MAC field in the packet). In 
+addition, the last hop of the last segment recomputes and verifies 
+the LHVF field (:math:`\sigma_{\text{LH}} = \sigma_{i}`, where i is 
+the last hop). If the verification fails, the packet is dropped.
+
+Procedures in EPIC Version 1
+----------------------------
+
+**Control plane:**
+The beacons have to additionally carry a new 16-byte authenticator 
+for each AS on the path. The new EPIC-authenticator is calculated in 
+almost the same way as in standard SCION, but with an additional 
+constant :math:`C_{\text{EPIC}}` prepended to the MAC input:    
+
+.. math::    
+    \begin{align}
+    \sigma_i^{\text{EPIC}} &= \text{MAC}_{K_i}(C_{\text{EPIC}} || 
+        TsPath || ExpTime_i || InIF_i || EgIF_i || \beta_i) \\
+    \sigma_i^{\text{P, EPIC}} &= \text{MAC}_{K_i}(C_{\text{EPIC}} || 
+        TsPath || ExpTime_i^P || InIF_i^P || 
+        EgIF_i^P || \beta_{i+1}) \\
+    where \\
+    C_{\text{EPIC}} &= 0x391c
+    \end{align}
+
+Note that the input to the MAC function now consists of 15 instead of 
+11 bytes, but still requires only one encryption operation for block 
+cipher based MACs. Also note that :math:`\beta_{0}^EPIC = \beta_{0}`. 
+Because the MAC-calculations are different, :math:`\beta_{i}^EPIC 
+\neq \beta_{i}` (for i > 0), however.
+
+**Data plane:**
+The source host fetches the path, including all the 16-byte EPIC 
+authenticators, from the path server. It also retrieves the 
+host-level DRKeys (:math:`K_i^S` between the source host and the 
+on-path ASes, and :math:`K_{SD}` between the source host and the 
+destination host) from the certificate server. The source then 
+calculates the Hop Validation Fields (:math:`V_i`) and the 
+Destination Validation Field (:math:`V_{\text{SD}}`):
+
+.. math::    
+    \begin{align}
+    V_i &= \text{MAC}_{K_i^{\text{S}}}(\text{PacketTimestamp}, 
+        \text{Origin}, \sigma_i^{\text{EPIC}}, \text{PayloadLen})
+        ~\text{[0:4]} \\
+    V_{\text{SD}} &= \text{MAC}_{K_{\text{SD}}}
+        (\text{PacketTimestamp, Path, Payload}) \\
+    where \\
+    \text{Path} &= (\text{TsPath}, \text{Address Header}, 
+        HI_1, ..., HI_n)\\
+    HI_i &= (\text{ExpTime}_i, \text{ConsIngress}_i, 
+        \text{ConsEgress}_i) \\
+    \end{align}
+
+Depending on the implementation of the MAC, we also need to prepend 
+the length of the input (additional 2 bytes). As in SCION, the source 
+writes all the :math:`\sigma_i^{\text{EPIC}}` / 
+:math:`\sigma_i^{\text{P, EPIC}}` to the MAC-subfield of the Hop 
+Fields, but in this case truncates the MAC to 2 bytes instead of 6 
+bytes. The :math:`V_i` are subsequently stored in the HVF-subfield of 
+the Hop Fields, and :math:`V_{\text{SD}}` in the DVF field of the 
+EPIC Path Type Header. The source host writes the necessary 
+:math:`\beta` to the SegID of the Info Fields as in standard SCION.
+
+The border routers perform the same operations as in SCION. In 
+addition, they derive the necessary DRKey (:math:`K_i^S`), and 
+recompute and validate the :math:`V_i`.
+
+Upon receiving a packet, the destination fetches :math:`K_{SD}` from 
+its local certificate server, recomputes :math:`V_{\text{SD}}` and 
+performs validation by comparing it to the DVF in the packet. 
+
+Configuration
+-------------
+Network operators should be able to clearly define which kind of 
+traffic (SCION, EPIC v0, EPIC v1, and other protocols) they want to
+allow. 
+Therefore, for each AS and every interface pair, an AS can be 
+configured with flags to allow only certain types of traffic: 
+
+.. math::    
+    \begin{align}
+    \text{AllowedTraffic(If_1, IF_2)} &= \text{(flag_{SCION}, 
+    flag_{EPIC v0}, flag_{EPIC v1})} 
+    \end{align}
+
+To exclusively allow SCION traffic (default) between interfaces 'x' 
+and 'y' we would set:
+
+.. math::    
+    \begin{align}
+    \text{AllowedTraffic(x, y)} &= \text{(1, 0, 0)} 
+    \end{align}
+
+And similarly to only allow EPIC traffic (version 0 and version 1):
+
+.. math::    
+    \begin{align}
+    \text{AllowedTraffic(x, y)} &= \text{(0, 1, 1)} 
+    \end{align}
+
+This affects both the control and the data plane. For example on pure 
+SCION paths, beacons do not collect the EPIC authenticators, and 
+during forwaring every non-SCION packet gets dropped.
+
+
+

--- a/doc/protocols/scion-header.rst
+++ b/doc/protocols/scion-header.rst
@@ -420,7 +420,7 @@ security of hidden paths.
 
 The EPIC-HP header has the following structure:
    - A *PacketTimestamp* field (8 bytes)
-   - The standard SCION header
+   - The path header for the standard SCION Path Type
    - A 4-byte *LHVF* (Last Hop Verification Field) 
 
 The EPIC-HP contains the full SCION header, and also the calculation of the MAC is identical. This allows 
@@ -790,10 +790,13 @@ It also contains the following per-AS fields:
 
 Cryptographic Primitives
 ------------------------
+
+.. _CASA: ./casa.rst
+
 In EPIC, hosts and ASes need to agree on what implementation of the 
 MAC they want to use. Different ASes may not necessarily agree on 
 one globally fixed MAC algorithm however. EPIC therefore leverages 
-CASA (Cryptographic Agility for SCION ASes), where each AS promotes 
+CASA_ (Cryptographic Agility for SCION ASes), where each AS promotes 
 the supported MAC algorithm in the beacons. This way the border 
 routers are still very efficient, as they do only have to support 
 the MAC specified by their AS. The source hosts know the required 

--- a/doc/protocols/scion-header.rst
+++ b/doc/protocols/scion-header.rst
@@ -741,15 +741,15 @@ the last authenticator of the last segment are the same as
 :math:`{\sigma_{\text{SH}}}` and :math:`{\sigma_{\text{LH}}}` in 
 EPIC-HP.
 
-Because every AS has to be able to decide whether it wants to 
-register the path as standard SCION path, it has to be possible to 
-remove the remaining 10 bytes of the authenticators from the 
-beacons, otherwise it would directly leak this information. However, 
-the beacons still have to be verifiable without this information. To 
-solve this problem, we suggest to *only add the hash* of the 10 
-bytes of the authenticators to the authenticated part of the 
-beacon. The 10 bytes of the authenticators would be added to the 
-beacon unauthenticated.
+.. Because every AS has to be able to decide whether it wants to 
+.. register the path as standard SCION path, it has to be possible to 
+.. remove the remaining 10 bytes of the authenticators from the 
+.. beacons, otherwise it would directly leak this information. However, 
+.. the beacons still have to be verifiable without this information. To 
+.. solve this problem, we suggest to *only add the hash* of the 10 
+.. bytes of the authenticators to the authenticated part of the 
+.. beacon. The 10 bytes of the authenticators would be added to the 
+.. beacon unauthenticated.
 
 **Data plane (EPIC Version 2):**
 The source host fetches the path, including all the 16-byte EPIC 
@@ -839,15 +839,13 @@ each AS, which means that the beacons also contain those flags.
 
 Summary of additional beacon extensions
 ---------------------------------------
-A beacon has to additionally carry the following fields:
-  - The remaining 10 bytes of the MAC.
-
-It also contains the following per-AS fields:
+A beacon contains the following per-AS fields:
   - The remaining 10 bytes of the MAC. 
   - AllowedD: Indicates which path types are allowed in the down 
     direction.
   - AllowedU: Indicates which path types are allowed in the up 
-    direction.
+    direction. (1 byte, could be more depending on how many path 
+    types should be supported in the future)
 
 Cryptographic Primitives
 ------------------------

--- a/doc/protocols/scion-header.rst
+++ b/doc/protocols/scion-header.rst
@@ -420,11 +420,13 @@ security of hidden paths.
 
 The EPIC-HP header has the following structure:
    - A *PacketTimestamp* field (8 bytes)
-   - The path header for the standard SCION Path Type
+   - The path header for the standard SCION Path Type, where one bit of the Path Meta Header is used to indicate whether the sender accepts SCION response packets.
    - A 4-byte *LHVF* (Last Hop Verification Field) 
 
-The EPIC-HP contains the full SCION header, and also the calculation of the MAC is identical. This allows 
+The EPIC-HP header contains the full SCION header, and also the calculation of the MAC is identical. This allows 
 the destination host to directly send back a SCION answer packet to the source by inverting the path.
+This is allowed from a security perspective, because the SCION answer packets do not leak information that would allow unauthorized entities to use the hidden path.
+To protect the services behind the hidden path from DoS-attacks (only authorized entities should be able to access the services, prevent downgrade to standard SCION), ASes need to be able to configure the border routers such that only certain Path Types are allowed (see configuration_ section). 
 
 ::
 
@@ -447,6 +449,20 @@ the destination host to directly send back a SCION answer packet to the source b
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                             LHVF                              |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+Path Meta Header
+----------------
+
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | C |  CurrHF   |S|   RSV   |  Seg0Len  |  Seg1Len  |  Seg2Len  |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+SCION-Response (S)
+  Indicates whether the sender accepts SCION response packets. A sender that is not behind a hidden path can set this flag so that the service knows it has to answer with SCION traffic. A sender that is protected by a hidden path itself does not set this flag, as its AS likely drops standard SCION packets - the service knows that it will have to answer with EPIC-HP instead.
 
 Packet Timestamp
 ----------------
@@ -483,7 +499,7 @@ TsRel
 
 TsRel has a precision of :math:`\text{21 \mu s}` and covers at least  
 one day (1 day and 63 minutes). When sending packets at high speeds 
-(more than one packet every :math:`\text{20 \mu s}`) or when using 
+(more than one packet every :math:`\text{21 \mu s}`) or when using 
 multiple cores, collisions may occur in TsRel. To solve this 
 problem, the source further identifies the packet using PckId.
 

--- a/doc/protocols/scion-header.rst
+++ b/doc/protocols/scion-header.rst
@@ -418,15 +418,20 @@ CurrHF := 0`` and ``if dstIA == self.IA: CurrHF := 1``.
 
 .. -------------------------------------------------------------------
 
-Path Type: EPIC
-===============
-The EPIC Path Type is equal to the SCION Path Type, except for the following additions:
-   - An additional *EV* (EPIC Version) field in the Path Meta Header.
-   - An additional *PacketTimestamp* field (8 bytes), which is 
-     placed at the very beginning of the header.
-   - Depending on the value of EV, the last Hop Field is either 
-     followed by the 4-byte *LHVF* (Last Hop Verification Field) or 
-     by the 16-byte *DVF* (Destination Validation Field).
+Path Type: EPIC-HP
+==================
+The EPIC-HP (EPIC for Hidden Paths) header provides improved path authorization for the last hop of the path. 
+In standard SCION, an attacker that once observed or brute-forced the hop authenticators for some path can use 
+them to send arbitrary traffic along this path. EPIC-HP solves this problem on the last hop, which is particularly important for the 
+security of hidden paths.
+
+The EPIC-HP header has the following structure:
+   - A *PacketTimestamp* field (8 bytes)
+   - The standard SCION header
+   - A 4-byte *LHVF* (Last Hop Verification Field) 
+
+The EPIC-HP contains the full SCION header, and also the calculation of the MAC is identical. This allows 
+the destination host to directly send back a SCION answer packet to the source by inverting the path.
 
 ::
 
@@ -447,13 +452,9 @@ The EPIC Path Type is equal to the SCION Path Type, except for the following add
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                           HopField                            |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                          DVF / LHVF                           |
+    |                             LHVF                              |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-The Packet Timestamp is at the beginning, so that other components 
-like the replay suppression system can access it immediately.
-Note that the part between PacketTimestamp and DVF/LHVF corresponds 
-to the standard SCION header.
 
 Packet Timestamp
 ----------------
@@ -515,119 +516,30 @@ CoreCounter
   by CoreID. Every time a core sends an EPIC packet, it increases 
   its core counter (modular addition by 1).
 
-
-Path Meta Header
-----------------
-::
-
-     0                   1                   2                   3
-     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    | C |  CurrHF   |  RSV  |EV |  Seg0Len  |  Seg1Len  |  Seg2Len  |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-EPIC Version (EV):
-   - **EV = 0:** Standard SCION with EPIC L1 only on the last hop of the 
-     last segment. In standard SCION, an attacker that once observed 
-     or brute-forced the hop authenticators for some path can use 
-     them to send arbitrary traffic along this path. EPIC Version 0 
-     solves this problem, which is particularly important for the 
-     security of hidden paths.
-   - **EV = 1:** Implements EPIC L2 (source authentication). Every 
-     AS on the path can verify the authenticity of every EPIC 
-     Version 1 packet.
-   - **EV = 2:** *unused (may be used for EPIC L3 in the future)*
-   - **EV = 3:** *unused*
-
-Info Field
-----------
-The EPIC Info Field is the same as the SCION Info Field.
-::
-
-     0                   1                   2                   3
-     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |r r r r r r P C|      RSV      |             SegID             |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                           Timestamp                           |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-
-Hop Field
----------
-For EPIC Version 0, the EPIC Hop Field is the same as the SCION Hop 
-Field, and also the calculation of the MAC is identical. This allows 
-the destination host to directly send back an answer to the source 
-by inverting the path.
-
-::
-
-     0                   1                   2                   3
-     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |r r r r r r I E|    ExpTime    |           ConsIngress         |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |        ConsEgress             |                               |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               +
-    |                              MAC                              |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-For EPIC Version 1, we reduce the size of the MAC field and 
-assign a 4-byte Hop Validation Field (HVF) to the freed space.
-The total size of the Hop Field stays the same (12 bytes).
-
-::
-
-     0                   1                   2                   3
-     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |r r r r r r I E|    ExpTime    |           ConsIngress         |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |        ConsEgress             |              MAC              |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                              HVF                              |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+Note that the Packet Timestamp is at the very beginning of the header, this allows other components (like the replay suppression system) to access it without having to go through any parsing overhead. To achieve an even higher precision of the timestamp, the source is free to allocate additional bits from the PckId to TsRel for this purpose.
 
 
 Last Hop Validation Field (LHVF)
 ----------------------------------
 ::
 
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                             LHVF                              |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-This 4-byte field is only present if the EPIC Version is 0. It 
-contains the EPIC L1 Hop Validation Field of the last hop of the 
-last segment. 
+This 4-byte field contains the Hop Validation Field of the last hop of the last segment. 
 
-Destination Validation Field (DVF)
-----------------------------------
-::
-
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                                                               |
-    +                                                               +
-    |                                                               |
-    +                              DVF                              +
-    |                                                               |
-    +                                                               +
-    |                                                               |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-The 16-byte Destination Validation Field is only present if the EPIC 
-Version is 1. The DVF contains the MAC calculated by the source host 
-to authenticate itself to the destination host.
 
 EPIC Header Length Calculation
 ------------------------------
 The length of the EPIC Path header is the same as the SCION Path
-header plus 8 bytes (Packet Timestamp), and plus 4 bytes in case of 
-EPIC version 0 or 16 bytes in case of EPIC version 1.
+header plus 8 bytes (Packet Timestamp), and plus 4 bytes for the LHVF.
 
 
-Procedures in EPIC Version 0
-----------------------------
+Procedures
+----------
 
 **Control plane:**
 The beaconing process is the same as for SCION, but the last hop not 
@@ -658,8 +570,115 @@ addition, the last hop of the last segment recomputes and verifies
 the LHVF field (:math:`\sigma_{\text{LH}} = \sigma_{i}`, where i is 
 the last hop). If the verification fails, the packet is dropped.
 
-Procedures in EPIC Version 1
-----------------------------
+
+
+
+
+
+
+
+
+
+
+.. -------------------------------------------------------------------
+
+Path Type: EPIC-SAPV
+====================
+The Path Type EPIC-SAPV (EPIC Source Authentication and Path Validation) contains the following parts:
+   - An 8-byte Packet Timestamp (same as for EPIC-HP).
+   - A slightly modified SCION header.
+   - A 16-byte *DVF* (Destination Validation Field).
+
+::
+
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                        PacketTimestamp                        |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                          PathMetaHdr                          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           InfoField                           |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                              ...                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           InfoField                           |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           HopField                            |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                              ...                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           HopField                            |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                              DVF                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
+SCION Header Modifications
+--------------------------
+EPIC-SAPV contains the standard SCION header with the following adaptations:
+   - Two reserved bits of the Meta Header are used to indicate the EPIC Version (EV).
+   - The size of the MAC (six bytes in standard SCION) inside the Hop Fields is reduced to two bytes, the four bytes of freed space are used for the Hop Validation Field (HVF). 
+
+Path Meta Header
+^^^^^^^^^^^^^^^^
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | C |  CurrHF   |  RSV  |EV |  Seg0Len  |  Seg1Len  |  Seg2Len  |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+EPIC Version (EV):
+   - **EV = 0:** Provides per-packet source authentication: every AS on the path can verify that the packet source is authentic.
+   - **EV = 1:** *unused (may be used for path validation in the future)*
+   - **EV = 2:** *unused*
+   - **EV = 3:** *unused*
+
+Hop Field
+^^^^^^^^^
+We reduce the size of the MAC field to 2 bytes and assign a 4-byte Hop Validation Field (HVF) to the freed space.
+The total size of the Hop Field stays the same (12 bytes).
+
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |r r r r r r I E|    ExpTime    |           ConsIngress         |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |        ConsEgress             |              MAC              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                              HVF                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+Destination Validation Field (DVF)
+----------------------------------
+::
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    +                                                               +
+    |                                                               |
+    +                              DVF                              +
+    |                                                               |
+    +                                                               +
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+The 16-byte Destination Validation Field is only present if the EPIC 
+Version is 1. The DVF contains the MAC calculated by the source host 
+to authenticate itself to the destination host.
+
+EPIC-SAPV Header Length Calculation
+-----------------------------------
+The length of the EPIC Path header is the same as the SCION Path
+header plus 8 bytes (Packet Timestamp), and plus 16 bytes for the DVF.
+
+Procedures
+----------
 
 **Control plane:**
 The beacons have to additionally carry a new 16-byte authenticator 
@@ -713,8 +732,8 @@ writes all the :math:`\sigma_i^{\text{EPIC}}` /
 :math:`\sigma_i^{\text{P, EPIC}}` to the MAC-subfield of the Hop 
 Fields, but in this case truncates the MAC to 2 bytes instead of 6 
 bytes. The :math:`V_i` are subsequently stored in the HVF-subfield of 
-the Hop Fields, and :math:`V_{\text{SD}}` in the DVF field of the 
-EPIC Path Type Header. The source host writes the necessary 
+the Hop Fields, and :math:`V_{\text{SD}}` in the DVF field. 
+The source host writes the necessary 
 :math:`\beta` to the SegID of the Info Fields as in standard SCION.
 
 The border routers perform the same operations as in SCION. In 
@@ -725,18 +744,28 @@ Upon receiving a packet, the destination fetches :math:`K_{SD}` from
 its local certificate server, recomputes :math:`V_{\text{SD}}` and 
 performs validation by comparing it to the DVF in the packet. 
 
+
+
+Details of the EPIC Path Types
+==============================
+
+Cryptographic Primitives
+------------------------
+
+
+
 Configuration
 -------------
 Network operators should be able to clearly define which kind of 
-traffic (SCION, EPIC v0, EPIC v1, and other protocols) they want to
+traffic (SCION, EPIC-HP, EPIC-SAPV, and other protocols) they want to
 allow. 
 Therefore, for each AS and every interface pair, an AS can be 
 configured with flags to allow only certain types of traffic: 
 
 .. math::    
     \begin{align}
-    \text{AllowedTraffic(If_1, IF_2)} &= \text{(flag_{SCION}, 
-    flag_{EPIC v0}, flag_{EPIC v1})} 
+    \text{AllowedTraffic(If_1, If_2)} &= \text{(flag_{SCION}, 
+    flag_\text{EPIC-HP}, flag_\text{EPIC-SAPV})} 
     \end{align}
 
 To exclusively allow SCION traffic (default) between interfaces 'x' 
@@ -747,7 +776,7 @@ and 'y' we would set:
     \text{AllowedTraffic(x, y)} &= \text{(1, 0, 0)} 
     \end{align}
 
-And similarly to only allow EPIC traffic (version 0 and version 1):
+And similarly to only allow EPIC traffic (EPIC-HP and EPIC-SAPV):
 
 .. math::    
     \begin{align}
@@ -757,6 +786,34 @@ And similarly to only allow EPIC traffic (version 0 and version 1):
 This affects both the control and the data plane. For example on pure 
 SCION paths, beacons do not collect the EPIC authenticators, and 
 during forwaring every non-SCION packet gets dropped.
+If an AS only wants to allow EPIC traffic, it still uses the normal  
+SCION beaconing mechanism, extended with the EPIC authenticators, 
+but drops non-EPIC packets in the data plane. 
+The beaconing mechanism has to be extended such that the beacon 
+contains information on which path types are supported for each AS,
+which means that the beacons also contain those flags.
+
+Summary of additional beacon extensions
+---------------------------------------
+A beacon has to additionally carry the following fields:
+  - The remaining 10 bytes of the MAC of the very last hop (for EPIC-HP).
+
+It also contains the following per-AS fields:
+  - AllowedD: Indicates which path types are allowed in the down 
+    direction.
+  - AllowedU: Indicates which path types are allowed in the up 
+    direction.
+  - The EPIC-SAPV authenticators: 
+    :math:`\sigma_i^{\text{EPIC}}` and 
+    :math:`\sigma_i^{\text{P, EPIC}}` respectively (16 bytes).
+
+
+
+
+
+
+
+
 
 
 


### PR DESCRIPTION
This pull request contains the EPIC specification, which is based on the discussion from [1].
With this, two new path types are introduced:
- EPIC-HP (EPIC for Hidden Paths)
- EPIC-SAPV (EPIC Source Authentication and Path Validation)

In addition, we propose CASA (Cryptographic Agility for SCION ASes), which allows different entities (ASes, hosts) to agree on the same cryptographic algorithms like PRFs and MACs.

[1] https://docs.google.com/document/d/1n7Gi-WXMM1RzbCS-e3FLdyKNdfI8_mI7I9ndSwjgDpM/edit?usp=sharing